### PR TITLE
Introduce oprerator get() on ForecastList class and use in adapter

### DIFF
--- a/app/src/main/java/me/worric/kotlinplayground/domain/model/DomainClasses.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/domain/model/DomainClasses.kt
@@ -1,5 +1,10 @@
 package me.worric.kotlinplayground.domain.model
 
-data class ForecastList(val city: String, val country: String, val dailyForecast: List<Forecast>)
+data class ForecastList(val city: String, val country: String, val dailyForecast: List<Forecast>) {
+    val size: Int
+        get() = dailyForecast.size
+
+    operator fun get(position: Int): Forecast = dailyForecast[position]
+}
 
 data class Forecast(val date: String, val description: String, val high: Int, val low: Int)

--- a/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
@@ -12,14 +12,14 @@ class ForecastListAdapter(val weekForecast: ForecastList) :
         return ViewHolder(TextView(parent.context))
     }
 
-    override fun getItemCount(): Int = weekForecast.dailyForecast.size
+    override fun getItemCount(): Int = weekForecast.size
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        with(weekForecast.dailyForecast[position]) {
+        with(weekForecast[position]) {
             holder.textView.text = "$date - $description - $high/$low"
         }
     }
 
-
     class ViewHolder(val textView: TextView) : RecyclerView.ViewHolder(textView)
+
 }


### PR DESCRIPTION
this PR introduces operator overloading on the `ForecastList` class, enabling clients to use the embedded list of `Forecast`s more directly