### PR TITLE
Clickable forecast list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,9 +26,11 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.anko:anko-common:$anko_version"
+    implementation "com.android.support:exifinterface:$support_lib_version"
     implementation "com.android.support:appcompat-v7:$support_lib_version"
     implementation "com.android.support:recyclerview-v7:$support_lib_version"
     implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/app/src/main/java/me/worric/kotlinplayground/domain/mappers/ForecastDataMapper.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/domain/mappers/ForecastDataMapper.kt
@@ -23,8 +23,13 @@ class ForecastDataMapper {
     }
 
     private fun convertForecastItemToDomain(forecast: Forecast): me.worric.kotlinplayground.domain.model.Forecast {
-        return ModelForecast(convertDate(forecast.dt), forecast.weather[0].description, forecast.temp.max.toInt(), forecast.temp.min.toInt())
+        return ModelForecast(convertDate(forecast.dt), forecast.weather[0].description,
+                forecast.temp.max.toInt(), forecast.temp.min.toInt(),
+                generateIconUrl(forecast.weather[0].icon))
     }
+
+    private fun generateIconUrl(iconCode: String): String =
+            "http://openweathermap.org/img/w/$iconCode.png"
 
     private fun convertDate(date: Long): String {
         val df = DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.getDefault())

--- a/app/src/main/java/me/worric/kotlinplayground/domain/model/DomainClasses.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/domain/model/DomainClasses.kt
@@ -7,4 +7,5 @@ data class ForecastList(val city: String, val country: String, val dailyForecast
     operator fun get(position: Int): Forecast = dailyForecast[position]
 }
 
-data class Forecast(val date: String, val description: String, val high: Int, val low: Int)
+data class Forecast(val date: String, val description: String, val high: Int, val low: Int,
+                    val iconUrl: String)

--- a/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
@@ -1,25 +1,53 @@
 package me.worric.kotlinplayground.ui
 
 import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
+import com.squareup.picasso.Picasso
+import me.worric.kotlinplayground.R
+import me.worric.kotlinplayground.domain.model.Forecast
 import me.worric.kotlinplayground.domain.model.ForecastList
+import me.worric.kotlinplayground.ui.utils.ctx
+import org.jetbrains.anko.find
 
-class ForecastListAdapter(val weekForecast: ForecastList) :
+class ForecastListAdapter(val weekForecast: ForecastList, val itemClick: OnItemClickListener) :
         RecyclerView.Adapter<ForecastListAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        return ViewHolder(TextView(parent.context))
+        val itemView = LayoutInflater.from(parent.ctx).inflate(R.layout.item_forecast, parent, false)
+        return ViewHolder(itemView, itemClick)
     }
 
     override fun getItemCount(): Int = weekForecast.size
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        with(weekForecast[position]) {
-            holder.textView.text = "$date - $description - $high/$low"
+        holder.bindForecast(weekForecast[position])
+    }
+
+    class ViewHolder(val view: View, val itemClick: OnItemClickListener) : RecyclerView.ViewHolder(view) {
+        private val iconView = view.find<ImageView>(R.id.icon)
+        private val dateView = view.find<TextView>(R.id.date)
+        private val descriptionView = view.find<TextView>(R.id.description)
+        private val maxTemperatureView = view.find<TextView>(R.id.maxTemperature)
+        private val minTemperatureView = view.find<TextView>(R.id.minTemperature)
+
+        fun bindForecast(forecast: Forecast) {
+            with(forecast) {
+                Picasso.get().load(iconUrl).into(iconView)
+                dateView.text = date
+                descriptionView.text = description
+                maxTemperatureView.text = "$high"
+                minTemperatureView.text = "${low}"
+                itemView.setOnClickListener { itemClick(this) }
+            }
         }
     }
 
-    class ViewHolder(val textView: TextView) : RecyclerView.ViewHolder(textView)
+    interface OnItemClickListener {
+        operator fun invoke(forecast: Forecast)
+    }
 
 }

--- a/app/src/main/java/me/worric/kotlinplayground/ui/MainActivity.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/MainActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import me.worric.kotlinplayground.R
 import me.worric.kotlinplayground.data.Person
 import me.worric.kotlinplayground.domain.commands.RequestForecastCommand
+import me.worric.kotlinplayground.domain.model.Forecast
 import org.jetbrains.anko.doAsync
 import org.jetbrains.anko.find
 import org.jetbrains.anko.uiThread
@@ -33,7 +34,14 @@ class MainActivity : AppCompatActivity() {
 
         doAsync {
             val result = RequestForecastCommand("94043").execute()
-            uiThread { forecastList.adapter = ForecastListAdapter(result) }
+            uiThread {
+                forecastList.adapter = ForecastListAdapter(result,
+                        object : ForecastListAdapter.OnItemClickListener {
+                            override fun invoke(forecast: Forecast) {
+                                toast(forecast.date)
+                            }
+                        })
+            }
         }
 
         val person = Person(name = "John", surname = "Smith")

--- a/app/src/main/java/me/worric/kotlinplayground/ui/utils/ViewExtensions.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/utils/ViewExtensions.kt
@@ -1,0 +1,7 @@
+package me.worric.kotlinplayground.ui.utils
+
+import android.content.Context
+import android.view.View
+
+val View.ctx: Context
+    get() = context

--- a/app/src/main/res/layout/item_forecast.xml
+++ b/app/src/main/res/layout/item_forecast.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        tools:src="@mipmap/ic_launcher" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:orientation="vertical"
+        android:layout_weight="1">
+
+        <TextView
+            android:id="@+id/date"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            tools:text="May 14, 2015" />
+
+        <TextView
+            android:id="@+id/description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+            tools:text="Light Rain" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/maxTemperature"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            tools:text="30" />
+
+        <TextView
+            android:id="@+id/minTemperature"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+            tools:text="15" />
+
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
This PR makes it so that the items in the `ForecastList` are clickable. It does so by introducing an interface in the adapter that is triggered when an item is clicked. The `MainActivity` supplies an implementation and reacts accordingly

At this time, all it does is toast the date of the selected `Forecast`