### PR TITLE
Make use of lambdas instead of object in click listener

### DIFF
--- a/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
@@ -13,7 +13,8 @@ import me.worric.kotlinplayground.domain.model.ForecastList
 import me.worric.kotlinplayground.ui.utils.ctx
 import org.jetbrains.anko.find
 
-class ForecastListAdapter(val weekForecast: ForecastList, val itemClick: OnItemClickListener) :
+class ForecastListAdapter(val weekForecast: ForecastList,
+                          val itemClick: (Forecast) -> Unit) :
         RecyclerView.Adapter<ForecastListAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -27,7 +28,9 @@ class ForecastListAdapter(val weekForecast: ForecastList, val itemClick: OnItemC
         holder.bindForecast(weekForecast[position])
     }
 
-    class ViewHolder(val view: View, val itemClick: OnItemClickListener) : RecyclerView.ViewHolder(view) {
+    class ViewHolder(val view: View,
+                     val itemClick: (Forecast) -> Unit) :
+            RecyclerView.ViewHolder(view) {
         private val iconView = view.find<ImageView>(R.id.icon)
         private val dateView = view.find<TextView>(R.id.date)
         private val descriptionView = view.find<TextView>(R.id.description)
@@ -44,10 +47,6 @@ class ForecastListAdapter(val weekForecast: ForecastList, val itemClick: OnItemC
                 itemView.setOnClickListener { itemClick(this) }
             }
         }
-    }
-
-    interface OnItemClickListener {
-        operator fun invoke(forecast: Forecast)
     }
 
 }

--- a/app/src/main/java/me/worric/kotlinplayground/ui/MainActivity.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/MainActivity.kt
@@ -8,7 +8,6 @@ import android.widget.Toast
 import me.worric.kotlinplayground.R
 import me.worric.kotlinplayground.data.Person
 import me.worric.kotlinplayground.domain.commands.RequestForecastCommand
-import me.worric.kotlinplayground.domain.model.Forecast
 import org.jetbrains.anko.doAsync
 import org.jetbrains.anko.find
 import org.jetbrains.anko.uiThread
@@ -34,13 +33,9 @@ class MainActivity : AppCompatActivity() {
 
         doAsync {
             val result = RequestForecastCommand("94043").execute()
-            uiThread {
-                forecastList.adapter = ForecastListAdapter(result,
-                        object : ForecastListAdapter.OnItemClickListener {
-                            override fun invoke(forecast: Forecast) {
-                                toast(forecast.date)
-                            }
-                        })
+            uiThread { _ ->
+                // Simplify even further by using "it"; then we avoid left side of arrow
+                forecastList.adapter = ForecastListAdapter(result) { toast(it.date) }
             }
         }
 


### PR DESCRIPTION
This PR makes it so that the `ItemClickListener` is substituted by a lambda instead of an anonymous inner class that implements the `ItemClickListener` interface.