### PR TITLE
Make use of the kotlin extensions plugin in MainActivity + adapter

### DIFF
--- a/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/ForecastListAdapter.kt
@@ -4,14 +4,12 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import com.squareup.picasso.Picasso
+import kotlinx.android.synthetic.main.item_forecast.view.*
 import me.worric.kotlinplayground.R
 import me.worric.kotlinplayground.domain.model.Forecast
 import me.worric.kotlinplayground.domain.model.ForecastList
 import me.worric.kotlinplayground.ui.utils.ctx
-import org.jetbrains.anko.find
 
 class ForecastListAdapter(val weekForecast: ForecastList,
                           val itemClick: (Forecast) -> Unit) :
@@ -31,19 +29,14 @@ class ForecastListAdapter(val weekForecast: ForecastList,
     class ViewHolder(val view: View,
                      val itemClick: (Forecast) -> Unit) :
             RecyclerView.ViewHolder(view) {
-        private val iconView = view.find<ImageView>(R.id.icon)
-        private val dateView = view.find<TextView>(R.id.date)
-        private val descriptionView = view.find<TextView>(R.id.description)
-        private val maxTemperatureView = view.find<TextView>(R.id.maxTemperature)
-        private val minTemperatureView = view.find<TextView>(R.id.minTemperature)
 
         fun bindForecast(forecast: Forecast) {
             with(forecast) {
-                Picasso.get().load(iconUrl).into(iconView)
-                dateView.text = date
-                descriptionView.text = description
-                maxTemperatureView.text = "$high"
-                minTemperatureView.text = "${low}"
+                Picasso.get().load(iconUrl).into(itemView.icon)
+                itemView.date.text = date
+                itemView.description.text = description
+                itemView.maxTemperature.text = "$high"
+                itemView.minTemperature.text = "${low}"
                 itemView.setOnClickListener { itemClick(this) }
             }
         }

--- a/app/src/main/java/me/worric/kotlinplayground/ui/MainActivity.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/MainActivity.kt
@@ -3,13 +3,12 @@ package me.worric.kotlinplayground.ui
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
 import android.widget.Toast
+import kotlinx.android.synthetic.main.activity_main.*
 import me.worric.kotlinplayground.R
 import me.worric.kotlinplayground.data.Person
 import me.worric.kotlinplayground.domain.commands.RequestForecastCommand
 import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.find
 import org.jetbrains.anko.uiThread
 
 class MainActivity : AppCompatActivity() {
@@ -28,7 +27,6 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val forecastList: RecyclerView = find(R.id.rv_forecast_list)
         forecastList.layoutManager = LinearLayoutManager(this)
 
         doAsync {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     tools:context=".ui.MainActivity">
 
     <android.support.v7.widget.RecyclerView
-        android:id="@+id/rv_forecast_list"
+        android:id="@+id/forecastList"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 


### PR DESCRIPTION
This PR makes it so that `MainActivity` and the `ForecastListAdapter` makes use of the Kotlin Android Extensions + plugin in order to save some boilerplate `find` code