### PR TITLE
Move object outside custom delegate class

### DIFF
--- a/app/src/main/java/me/worric/kotlinplayground/App.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/App.kt
@@ -5,7 +5,7 @@ import android.app.Application
 class App : Application() {
 
     companion object {
-        var instance: App by NotNullSingleValue()
+        var instance: App by DelegatesExt.notNullSingleValue()
     }
 
     override fun onCreate() {

--- a/app/src/main/java/me/worric/kotlinplayground/NotNullSingleValue.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/NotNullSingleValue.kt
@@ -15,8 +15,8 @@ class NotNullSingleValue<T> {
         else throw IllegalStateException("${property.name} already initialized")
     }
 
-    object DelegatesExt {
-        fun <T> notNullSingleValue() = NotNullSingleValue<T>()
-    }
+}
 
+object DelegatesExt {
+    fun <T> notNullSingleValue() = NotNullSingleValue<T>()
 }


### PR DESCRIPTION
This PR fixes a small bug where the delegate object in the custom `App` class wasn't used correctly.