### PR TITLE
Update support lib to rc02 and const.layout to 1.1.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation "com.android.support:recyclerview-v7:$support_lib_version"
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.2.61'
     ext.anko_version = '0.10.5'
-    ext.support_lib_version = '28.0.0-rc01'
+    ext.support_lib_version = '28.0.0-rc02'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
This PR update both support library version to 28.0.0-rc02 as well as constraint layout version to 1.1.3