### PR TITLE
Implement changes from chapter 26 (coroutines)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.anko:anko-common:$anko_version"
     implementation "org.jetbrains.anko:anko-sqlite:$anko_version"
+    implementation "org.jetbrains.anko:anko-coroutines:$anko_version"
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.picasso:picasso:2.71828'

--- a/app/src/main/java/me/worric/kotlinplayground/ui/adapters/ForecastListAdapter.kt
+++ b/app/src/main/java/me/worric/kotlinplayground/ui/adapters/ForecastListAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.item_forecast.view.*
 import me.worric.kotlinplayground.R
 import me.worric.kotlinplayground.domain.model.Forecast
@@ -31,7 +32,7 @@ class ForecastListAdapter(val weekForecast: ForecastList,
 
         fun bindForecast(forecast: Forecast) {
             with(forecast) {
-//                Picasso.get().load(iconUrl).into(itemView.icon)
+                Picasso.get().load(iconUrl).into(itemView.icon)
                 itemView.date.text = date.toDateString()
                 itemView.description.text = description
                 itemView.maxTemperature.text = "$high"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.3.0'
-    ext.anko_version = '0.10.5'
+    ext.anko_version = '0.10.8'
     ext.support_lib_version = '28.0.0'
     repositories {
         google()


### PR DESCRIPTION
This PR implements the changes from the 26th chapter of the book on coroutines.

However, since coroutines have finally graduated, the code differs from the book by dropping the use of Anko for handling coroutines. Instead, the native methods `GlobalScope.launch` and `async` are used, and Anko is only used for its `asReference()` method, which generates a `WeakReference` object containing the current `Activity` or `Fragment` on which to perform certain actions when the code in the coroutines is unsuspended.